### PR TITLE
Fix article background and button text colors

### DIFF
--- a/src/components/AgencyDirectory.astro
+++ b/src/components/AgencyDirectory.astro
@@ -377,24 +377,6 @@ const types = [
     gap: 0.5rem;
   }
 
-  .link-btn {
-    display: inline-block;
-    padding: 0.375rem 0.75rem;
-    font-size: 0.8125rem;
-    text-decoration: none;
-    background-color: var(--pico-secondary-background);
-    color: var(--pico-color);
-    border: 1px solid var(--border-color);
-    border-radius: var(--pico-border-radius);
-    transition: all 0.2s ease;
-  }
-
-  .link-btn:hover {
-    background-color: var(--primary);
-    color: white;
-    border-color: var(--primary);
-  }
-
   .no-results {
     text-align: center;
     padding: 3rem 1rem;

--- a/src/components/FireMaps.astro
+++ b/src/components/FireMaps.astro
@@ -68,7 +68,7 @@ const mapTabs: MapTab[] = [
         <h3>{tab.name}</h3>
         <p class="card-description" style="color: var(--pico-color);">{tab.description}</p>
         <p class="card-details">{tab.details}</p>
-        <a href={tab.url} target="_blank" rel="noopener noreferrer" class="btn-primary btn-primary-lg">
+        <a href={tab.url} target="_blank" rel="noopener noreferrer" class="link-btn">
           Launch Map →
         </a>
       </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -50,6 +50,11 @@ body {
   padding: 0;
 }
 
+/* Remove PicoCSS article background */
+article {
+  background-color: transparent;
+}
+
 /* Layout structure */
 .site-layout {
   display: grid;
@@ -518,6 +523,27 @@ body {
 
 .btn-primary-lg {
   padding: 0.75rem 1.25rem;
+}
+
+/* Link-style buttons (subtle, outline style) */
+.link-btn {
+  display: inline-block;
+  padding: 0.625rem 1rem;
+  font-size: 0.9375rem;
+  text-decoration: none;
+  background-color: var(--pico-secondary-background);
+  color: var(--pico-color);
+  border: 1px solid var(--border-color);
+  border-radius: var(--pico-border-radius);
+  transition: all 0.2s ease;
+  font-weight: 500;
+  text-align: center;
+}
+
+.link-btn:hover {
+  background-color: var(--primary);
+  color: white;
+  border-color: var(--primary);
 }
 
 /* Secondary footer/tip sections */


### PR DESCRIPTION
- Remove PicoCSS article background color to prevent visual conflicts
- Consolidate link-btn style into global.css for consistency
- Update FireMaps to use link-btn instead of btn-primary, fixing green-on-green illegibility issue
- Ensure button styles are consistent between fire and agency pages