### PR TITLE
Remove fuse.js dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ This site provides up-to-date information on:
 Built with:
 - [Astro](https://astro.build/) - Modern static site generator
 - [PicoCSS](https://github.com/Yohn/PicoCSS) - Minimal CSS framework with CSS variables
-- Client-side search powered by [Fuse.js](https://fusejs.io/)
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^4.3.10",
         "@astrojs/sitemap": "^3.6.0",
-        "astro": "^5.15.5",
-        "fuse.js": "^7.0.0"
+        "astro": "^5.15.5"
       },
       "devDependencies": {
         "@yohns/picocss": "^2.2.10"
@@ -1632,7 +1631,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2598,15 +2596,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/fuse.js": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
-      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -4801,7 +4790,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.2.tgz",
       "integrity": "sha512-MHngMYwGJVi6Fmnk6ISmnk7JAHRNF0UkuucA0CUW3N3a4KnONPEZz+vUanQP/ZC/iY1Qkf3bwPWzyY84wEks1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -5514,7 +5502,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5713,7 +5700,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   "dependencies": {
     "astro": "^5.15.5",
     "@astrojs/mdx": "^4.3.10",
-    "@astrojs/sitemap": "^3.6.0",
-    "fuse.js": "^7.0.0"
+    "@astrojs/sitemap": "^3.6.0"
   },
   "devDependencies": {
     "@yohns/picocss": "^2.2.10"


### PR DESCRIPTION
Removed unused fuse.js dependency from package.json and updated README.md to reflect that the project no longer uses client-side search.